### PR TITLE
Handle a schema value for Postgresql

### DIFF
--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -6,6 +6,7 @@ const config = require('./env').getConfig()
 migrate({
   connectionString: config.connectionString,
   path: config.scriptsPath,
+  schema: config.schema || 'public',
   tableName: config.tableName,
   targetVersion: config.targetVersion || 0,
   printStatus: true,

--- a/bin/db-rollback
+++ b/bin/db-rollback
@@ -8,6 +8,7 @@ const config = require('./env').getConfig()
 rollback({
   connectionString: config.connectionString,
   path: config.scriptsPath,
+  schema: config.schema || 'public',
   tableName: config.tableName,
   targetVersion: config.targetVersion || '-1',
   printStatus: true,

--- a/bin/db-status
+++ b/bin/db-status
@@ -8,6 +8,7 @@ const config = require('./env').getConfig()
 status({
   connectionString: config.connectionString,
   path: config.scriptsPath,
+  schema: config.schema || 'public',
   tableName: config.tableName,
   dbDriver: config.dbDriver
 })

--- a/lib/domain/persister/mysql.js
+++ b/lib/domain/persister/mysql.js
@@ -19,7 +19,9 @@ const GET_ALL_SQL = 'SELECT id, description, migrated_at FROM %s ORDER BY id DES
 const ADD_VERSION_SQL = 'INSERT INTO %s (id, description, migrated_at) VALUES (?, ?, ?)'
 const REMOVE_VERSION_SQL = 'DELETE FROM %s WHERE id = ?'
 
-function createMysqlPersister (client, tableName) {
+function createMysqlPersister (client, tableName, schema) {
+  const schemaTable = schema === 'public' ? tableName : schema + '.' + tableName;
+
   const queryValue = (sql, params) =>
     client
       .query(sql, params)
@@ -33,22 +35,22 @@ function createMysqlPersister (client, tableName) {
   const checkTableExists = () => queryValue(CHECK_TABLE_SQL, [client.connection.config.database, tableName])
 
   const createTable = () =>
-    client.query(util.format(CREATE_TABLE_SQL, tableName))
+    client.query(util.format(CREATE_TABLE_SQL, schemaTable))
 
   const getLastVersion = () =>
-    queryValue(util.format(LAST_VERSION_SQL, tableName))
+    queryValue(util.format(LAST_VERSION_SQL, schemaTable))
 
-  const getAll = () => client.query(util.format(GET_ALL_SQL, tableName))
+  const getAll = () => client.query(util.format(GET_ALL_SQL, schemaTable))
 
   const addVersion = (version, description) =>
-    client.query(util.format(ADD_VERSION_SQL, tableName), [
+    client.query(util.format(ADD_VERSION_SQL, schemaTable), [
       version,
       description,
       new Date()
     ])
 
   const removeVersion = version =>
-    client.query(util.format(REMOVE_VERSION_SQL, tableName), [version])
+    client.query(util.format(REMOVE_VERSION_SQL, schemaTable), [version])
 
   const executeRawQuery = async sql => {
     const queries = sql.split(';').filter(q => q.trim() != '')
@@ -75,7 +77,7 @@ function createMysqlPersister (client, tableName) {
 }
 
 module.exports = {
-  create: async (connectionString, tableName) => {
+  create: async (connectionString, tableName, schema) => {
     let client
     const maxTries = (process.env.DB_CONNECT_MAX_ATTEMPTS || 25) - 1
     const waitMsec = process.env.DB_CONNECT_NEXT_ATTEMPT_DELAY || 1000
@@ -92,6 +94,6 @@ module.exports = {
       }
     }
 
-    return createMysqlPersister(client, tableName)
+    return createMysqlPersister(client, tableName, schema)
   }
 }

--- a/lib/domain/persister/mysql.js
+++ b/lib/domain/persister/mysql.js
@@ -20,7 +20,8 @@ const ADD_VERSION_SQL = 'INSERT INTO %s (id, description, migrated_at) VALUES (?
 const REMOVE_VERSION_SQL = 'DELETE FROM %s WHERE id = ?'
 
 function createMysqlPersister (client, tableName, schema) {
-  const schemaTable = schema === 'public' ? tableName : schema + '.' + tableName;
+  // MYSQL don't care about schema
+  const schemaTable = tableName;
 
   const queryValue = (sql, params) =>
     client

--- a/lib/domain/persister/postgres.js
+++ b/lib/domain/persister/postgres.js
@@ -18,7 +18,10 @@ const GET_ALL_SQL = 'SELECT id, description, migrated_at FROM %s ORDER BY id DES
 const ADD_VERSION_SQL = 'INSERT INTO %s (id, description) VALUES ($1, $2)'
 const REMOVE_VERSION_SQL = 'DELETE FROM %s WHERE id = $1'
 
-function createPostgresPersister (client, tableName) {
+function createPostgresPersister (client, tableName, schema) {
+
+  const schemaTable = schema === 'public' ? tableName : schema + '.' + tableName;
+
   const queryValue = (sql, params) =>
     client
       .query(sql, params)
@@ -28,27 +31,27 @@ function createPostgresPersister (client, tableName) {
 
   const commitTransaction = () => client.query('COMMIT')
 
-  const checkTableExists = () => queryValue(CHECK_TABLE_SQL, [ tableName.contains('.') ? tableName.slice(tableName.indexOf('.') + 1, tableName.length) : tableName ])
+  const checkTableExists = () => queryValue(CHECK_TABLE_SQL, [ tableName ])
 
   const createTable = () =>
-    client.query(util.format(CREATE_TABLE_SQL, tableName))
+    client.query(util.format(CREATE_TABLE_SQL, schemaTable))
 
   const getLastVersion = () =>
-    queryValue(util.format(LAST_VERSION_SQL, tableName))
+    queryValue(util.format(LAST_VERSION_SQL, schemaTable))
 
   const getAll = () =>
     client
-      .query(util.format(GET_ALL_SQL, tableName))
+      .query(util.format(GET_ALL_SQL, schemaTable))
       .then(result => result.rows)
 
   const addVersion = (version, description) =>
-    client.query(util.format(ADD_VERSION_SQL, tableName), [
+    client.query(util.format(ADD_VERSION_SQL, schemaTable), [
       version,
       description
     ])
 
   const removeVersion = version =>
-    client.query(util.format(REMOVE_VERSION_SQL, tableName), [version])
+    client.query(util.format(REMOVE_VERSION_SQL, schemaTable), [version])
 
   const executeRawQuery = async sql =>
     client.query(sql).then(result => result.rows)
@@ -70,7 +73,7 @@ function createPostgresPersister (client, tableName) {
 }
 
 module.exports = {
-  create: async (connectionString, tableName) => {
+  create: async (connectionString, tableName, schema) => {
     const pool = new pg.Pool({
       connectionString: connectionString
     })
@@ -91,6 +94,6 @@ module.exports = {
       }
     }
 
-    return createPostgresPersister(client, tableName)
+    return createPostgresPersister(client, tableName, schema)
   }
 }

--- a/lib/domain/persister/postgres.js
+++ b/lib/domain/persister/postgres.js
@@ -28,7 +28,7 @@ function createPostgresPersister (client, tableName) {
 
   const commitTransaction = () => client.query('COMMIT')
 
-  const checkTableExists = () => queryValue(CHECK_TABLE_SQL, [tableName])
+  const checkTableExists = () => queryValue(CHECK_TABLE_SQL, [ tableName.contains('.') ? tableName.slice(tableName.indexOf('.') + 1, tableName.length) : tableName ])
 
   const createTable = () =>
     client.query(util.format(CREATE_TABLE_SQL, tableName))

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -9,6 +9,7 @@ const messages = require('./infrastructure/messages')
 async function migrate (options) {
   const connectionString = options.connectionString
   const targetVersion = options.targetVersion || 0
+  const schema = options.schema || 'public'
   const currentPath = options.path || '.'
   const tableName = options.tableName || 'migrations'
   const dbDriver = options.dbDriver || 'postgres'
@@ -17,7 +18,7 @@ async function migrate (options) {
   try {
     const persisterProvider = require('./domain/persister/' + dbDriver)
 
-    persister = await persisterProvider.create(connectionString, tableName)
+    persister = await persisterProvider.create(connectionString, tableName, schema)
 
     await persister.beginTransaction()
 

--- a/lib/rollback.js
+++ b/lib/rollback.js
@@ -10,6 +10,7 @@ async function rollback (options) {
   const connectionString = options.connectionString
   const targetVersion = options.targetVersion || -1
   const currentPath = options.path || '.'
+  const schema = options.schema || 'public'
   const tableName = options.tableName || 'migrations'
   const dbDriver = options.dbDriver || 'postgres'
   let persister
@@ -17,7 +18,7 @@ async function rollback (options) {
   try {
     const persisterProvider = require('./domain/persister/' + dbDriver)
 
-    persister = await persisterProvider.create(connectionString, tableName)
+    persister = await persisterProvider.create(connectionString, tableName, schema)
 
     await persister.beginTransaction()
 

--- a/lib/status.js
+++ b/lib/status.js
@@ -13,13 +13,14 @@ const VersionRepository = require('./domain/repository/version-repository')
 async function status (options) {
   const connectionString = options.connectionString
   const currentPath = options.path || '.'
+  const schema = options.schema || 'public'
   const tableName = options.tableName || 'version'
   const dbDriver = options.dbDriver || 'postgres'
   let persister
 
   try {
     const persisterProvider = require('./domain/persister/' + dbDriver)
-    persister = await persisterProvider.create(connectionString, tableName)
+    persister = await persisterProvider.create(connectionString, tableName, schema)
 
     const scriptService = new ScriptService(
       new ScriptRepository(fs, persister),


### PR DESCRIPTION
This allows postgresql users to specify a schema to perform operations against. This is only needed because node-postrges uses an old version of postgres-connection-string where setting currentSchema=myschema as a query parameter to the DB URL does not work.