### PR TITLE
Fix version exists method

### DIFF
--- a/lib/domain/service/script-service.js
+++ b/lib/domain/service/script-service.js
@@ -115,7 +115,7 @@ class ScriptService {
   }
 
   versionExists (fileList, version) {
-    return _.findIndex(fileList, 'version', parseInt(version)) > -1
+    return _.findIndex(fileList, {'version': parseInt(version)}) > -1
   }
 
   execute (query) {


### PR DESCRIPTION
The versionExists method use lodash findIndex with three arguments, but it must be only two (at least in this implementation without fromIndex) and the second should be the predicate that filter the values in the iterator.

It can be:
`_.findIndex(fileList, {'version': parseInt(version)})`

Or:
`_.findIndex(fileList, ['version', parseInt(version)])`